### PR TITLE
Update pyqt5_lesson_05.py

### DIFF
--- a/pyqt5_lesson_05.py
+++ b/pyqt5_lesson_05.py
@@ -44,7 +44,7 @@ class window(QMainWindow):
         btn.clicked.connect(self.close_application)
 
         btn.resize(btn.sizeHint())
-        btn.move(0, 0)
+        btn.move(0, 100)
         self.show()
 
     def close_application(self):


### PR DESCRIPTION
Without moving the quit button down, the menubar (the purpose of this lesson) won't be visible and accesible.